### PR TITLE
Avoid failing when no options are provided

### DIFF
--- a/libs/copydirSync.js
+++ b/libs/copydirSync.js
@@ -14,6 +14,7 @@ function copydirSync(from, to, options) {
       filter: options
     };
   }
+  if(typeof options === 'undefined') options = {}
   if(typeof options.cover === 'undefined') {
     options.cover = true;
   }


### PR DESCRIPTION
When no options are provided, next line fails checking for cover from undefined