### PR TITLE
fix: call filter with correct signature

### DIFF
--- a/libs/copydir.js
+++ b/libs/copydir.js
@@ -38,7 +38,7 @@ function copydir(from, to, options, callback) {
         stats.isFile() ? 'file' :
         stats.isSymbolicLink() ? 'symbolicLink' :
         '';
-      var valid = options.filter(statsname, from, path.dirname(from), path.basename(from));
+      var valid = options.filter(statsname, path.dirname(from), path.basename(from));
       if (statsname === 'directory' || statsname === 'symbolicLink') {
         // Directory or SymbolicLink
         if(valid) {

--- a/libs/copydirSync.js
+++ b/libs/copydirSync.js
@@ -26,7 +26,7 @@ function copydirSync(from, to, options) {
     stats.isFile() ? 'file' :
     stats.isSymbolicLink() ? 'symbolicLink' :
     '';
-  var valid = options.filter(statsname, from, path.dirname(from), path.basename(from));
+  var valid = options.filter(statsname, path.dirname(from), path.basename(from));
   if (statsname === 'directory' || statsname === 'symbolicLink') {
     // Directory or SymbolicLink
     if(valid) {


### PR DESCRIPTION
Hello pillys!

your node module is used in the @wordpress/env package and there a filter function is applied. I ran into troubles by reinitializing the project several times and tracked it down to the copyDir function.

The used filter function validates the filename and does not match the correct way due to the fact that the parameters provided differ from the documentation.

I guess that it shoud be the way as it is documented and corrected the call of the filter function accordingly.
