### PR TITLE
Use native fs.copyFile when available

### DIFF
--- a/libs/copydir.js
+++ b/libs/copydir.js
@@ -145,6 +145,20 @@ function utimes(f, mode, callback) {
 }
 
 function writeFile(from, to, options, stats, callback) {
+
+  if(typeof fs.copyFile === "function"){
+    fs.copyFile(from, to, function(err) {
+        if(err) {
+          callback(err);
+        } else {
+          options.debug && console.log('>> ' + to);
+          rewrite(to, options, stats, callback);
+        }
+      })
+
+    return;
+  }
+
   fs.readFile(from, 'binary', function(err, data) {
     if(err) {
       callback(err);

--- a/libs/copydirSync.js
+++ b/libs/copydirSync.js
@@ -78,7 +78,13 @@ function copyFromArraySync(files, from, to, options) {
 }
 
 function writeFileSync(from, to, options, stats) {
-  fs.writeFileSync(to, fs.readFileSync(from, 'binary'), 'binary');
+
+  if(typeof fs.copyFileSync === "function"){
+    fs.copyFileSync(from, to);
+  } else {
+    fs.writeFileSync(to, fs.readFileSync(from, 'binary'), 'binary');
+  }
+
   options.debug && console.log('>> ' + to);
   rewriteSync(to, options, stats);
 }


### PR DESCRIPTION
`fs.copyFile` was introduced in node 8.5 and should be much faster and use much less memory. This PR uses this native function when available.
I have tested that the file structure is identical when this method is used but have not tested that functionality on node 8 is unaffected.